### PR TITLE
(fix) : clean up code carried over from supply-orders

### DIFF
--- a/packages/esm-medical-supply-dispensing-app/src/routes.json
+++ b/packages/esm-medical-supply-dispensing-app/src/routes.json
@@ -4,29 +4,12 @@
     "fhir2": ">=1.2",
     "webservices.rest": "^2.24.0"
   },
-  "extensions": [
-    {
-      "name": "medical-supply-order-panel",
-      "component": "medicalSupplyOrderPanel",
-      "slot": "order-basket-slot",
-      "order": 5
-    }
-  
-  ],
-  "workspaces": [
-    {
-      "name": "add-medical-supply-order",
-      "type": "order",
-      "component": "addMedicalSupplyOrderWorkspace",
-      "title": "addMedicalSupplyOrderWorkspaceTitle"
-     
-      
-    }
-  ],
+  "extensions": [],
+  "workspaces": [],
   "pages": [
     {
       "component": "root",
-      "route": "medicalsupply"
+      "route": "medical-supply-dispensing"
     }
   ]
 }


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Remove resulting in duplicate `medical-supply-order` panel at the order-basket extension.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
