### PR TITLE
(feat) KHP3-7654: Hide transition button on the orders esm for patients doesn't have an active visit

### DIFF
--- a/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
+++ b/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
@@ -10,7 +10,11 @@ interface TransitionLatestQueueEntryButtonProps {
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
   const { activeVisit, isLoading } = useVisit(patientUuid);
+  const shouldHideButton = !activeVisit;
   const { t } = useTranslation();
+  if (shouldHideButton) {
+    return null;
+  }
 
   const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
@@ -29,8 +33,7 @@ const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButto
       kind="tertiary"
       onClick={handleLaunchModal}
       renderIcon={AirlineManageGates}
-      size="sm"
-      disabled={!activeVisit}>
+      size="sm">
       {t('transition', 'Transition')}
     </Button>
   );

--- a/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
+++ b/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
@@ -1,31 +1,36 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import styles from './transition-latest-queue-entry-button.scss';
-import { showModal } from '@openmrs/esm-framework';
-import { Button } from '@carbon/react';
+import { Button, InlineLoading } from '@carbon/react';
 import { AirlineManageGates } from '@carbon/react/icons';
+import { showModal, useVisit } from '@openmrs/esm-framework';
 
 interface TransitionLatestQueueEntryButtonProps {
   patientUuid: string;
 }
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
+  const { activeVisit, isLoading } = useVisit(patientUuid);
   const { t } = useTranslation();
 
-  const launchModal = () => {
+  const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
       closeModal: () => dispose(),
-      patientUuid,
+      activeVisit,
     });
   };
 
+  if (isLoading) {
+    return <InlineLoading description={t('loading', 'Loading...')} />;
+  }
+
   return (
     <Button
+      iconDescription={t('transitionPatientToNewQueue', 'Transition patient to new queue')}
       kind="tertiary"
-      className={styles.addPatientToQueue}
-      onClick={launchModal}
+      onClick={handleLaunchModal}
+      renderIcon={AirlineManageGates}
       size="sm"
-      renderIcon={() => <AirlineManageGates size={18} />}>
+      disabled={!activeVisit}>
       {t('transition', 'Transition')}
     </Button>
   );

--- a/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
+++ b/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { showModal, useVisit } from '@openmrs/esm-framework';
+import TransitionLatestQueueEntryButton from './transition-latest-queue-entry-button.component';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  showModal: jest.fn(),
+  useVisit: jest.fn(),
+}));
+
+describe('TransitionLatestQueueEntryButton', () => {
+  const patientUuid = 'patient-uuid';
+  const mockActiveVisit = { uuid: 'visit-uuid', display: 'Test Visit' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: mockActiveVisit,
+      isLoading: false,
+    });
+  });
+
+  it('should render a button', () => {
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByRole('button', { name: /transition/i })).toBeInTheDocument();
+  });
+
+  it('should launch the transition queue modal when clicked', async () => {
+    const user = userEvent.setup();
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    await user.click(screen.getByRole('button', { name: /transition/i }));
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+    expect(showModal).toHaveBeenCalledWith(
+      'transition-patient-to-latest-queue-modal',
+      expect.objectContaining({
+        closeModal: expect.any(Function),
+        activeVisit: mockActiveVisit,
+      }),
+    );
+  });
+
+  it('should show loading state when visit data is loading', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: true,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should disable the button when no active visit exists', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: false,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
+  });
+});

--- a/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
+++ b/packages/esm-imaging-orders-app/src/imaging-tabs/test-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
@@ -21,7 +21,7 @@ describe('TransitionLatestQueueEntryButton', () => {
     });
   });
 
-  it('should render a button', () => {
+  it('should render a button when an active visit exists', () => {
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
     expect(screen.getByRole('button', { name: /transition/i })).toBeInTheDocument();
@@ -51,11 +51,10 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('should disable the button when no active visit exists', () => {
+  it('should not render the button when no active visit exists', () => {
     (useVisit as jest.Mock).mockReturnValue({
       activeVisit: null,
       isLoading: false,
@@ -63,6 +62,6 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /transition/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
+++ b/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
@@ -10,7 +10,11 @@ interface TransitionLatestQueueEntryButtonProps {
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
   const { activeVisit, isLoading } = useVisit(patientUuid);
+  const shouldHideButton = !activeVisit;
   const { t } = useTranslation();
+  if (shouldHideButton) {
+    return null;
+  }
 
   const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
@@ -29,8 +33,7 @@ const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButto
       kind="tertiary"
       onClick={handleLaunchModal}
       renderIcon={AirlineManageGates}
-      size="sm"
-      disabled={!activeVisit}>
+      size="sm">
       {t('transition', 'Transition')}
     </Button>
   );

--- a/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
+++ b/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.component.tsx
@@ -1,31 +1,36 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import styles from './transition-latest-queue-entry-button.scss';
-import { showModal } from '@openmrs/esm-framework';
-import { Button } from '@carbon/react';
+import { Button, InlineLoading } from '@carbon/react';
 import { AirlineManageGates } from '@carbon/react/icons';
+import { showModal, useVisit } from '@openmrs/esm-framework';
 
 interface TransitionLatestQueueEntryButtonProps {
   patientUuid: string;
 }
 
 const TransitionLatestQueueEntryButton: React.FC<TransitionLatestQueueEntryButtonProps> = ({ patientUuid }) => {
+  const { activeVisit, isLoading } = useVisit(patientUuid);
   const { t } = useTranslation();
 
-  const launchModal = () => {
+  const handleLaunchModal = () => {
     const dispose = showModal('transition-patient-to-latest-queue-modal', {
       closeModal: () => dispose(),
-      patientUuid,
+      activeVisit,
     });
   };
 
+  if (isLoading) {
+    return <InlineLoading description={t('loading', 'Loading...')} />;
+  }
+
   return (
     <Button
+      iconDescription={t('transitionPatientToNewQueue', 'Transition patient to new queue')}
       kind="tertiary"
-      className={styles.addPatientToQueue}
-      onClick={launchModal}
+      onClick={handleLaunchModal}
+      renderIcon={AirlineManageGates}
       size="sm"
-      renderIcon={() => <AirlineManageGates size={18} />}>
+      disabled={!activeVisit}>
       {t('transition', 'Transition')}
     </Button>
   );

--- a/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.scss
+++ b/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.scss
@@ -1,6 +1,7 @@
 @use '@carbon/layout';
 @use '@carbon/styles/scss/type';
 
+// TODO: refactor to use esm-style-guide
 .addPatientToQueue {
   --cds-layout-size-height-context: var(--cds-layout-size-height-sm, 2rem);
   --cds-layout-size-height: var(--cds-layout-size-height-context);

--- a/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
+++ b/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { showModal, useVisit } from '@openmrs/esm-framework';
+import TransitionLatestQueueEntryButton from './transition-latest-queue-entry-button.component';
+
+jest.mock('@openmrs/esm-framework', () => ({
+  showModal: jest.fn(),
+  useVisit: jest.fn(),
+}));
+
+describe('TransitionLatestQueueEntryButton', () => {
+  const patientUuid = 'patient-uuid';
+  const mockActiveVisit = { uuid: 'visit-uuid', display: 'Test Visit' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: mockActiveVisit,
+      isLoading: false,
+    });
+  });
+
+  it('should render a button', () => {
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByRole('button', { name: /transition/i })).toBeInTheDocument();
+  });
+
+  it('should launch the transition queue modal when clicked', async () => {
+    const user = userEvent.setup();
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    await user.click(screen.getByRole('button', { name: /transition/i }));
+
+    expect(showModal).toHaveBeenCalledTimes(1);
+    expect(showModal).toHaveBeenCalledWith(
+      'transition-patient-to-latest-queue-modal',
+      expect.objectContaining({
+        closeModal: expect.any(Function),
+        activeVisit: mockActiveVisit,
+      }),
+    );
+  });
+
+  it('should show loading state when visit data is loading', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: true,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should disable the button when no active visit exists', () => {
+    (useVisit as jest.Mock).mockReturnValue({
+      activeVisit: null,
+      isLoading: false,
+    });
+
+    render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
+
+    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
+  });
+});

--- a/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
+++ b/packages/esm-procedure-orders-app/src/procedures-ordered/transition-patient-new-queue/transition-latest-queue-entry-button.test.tsx
@@ -21,7 +21,7 @@ describe('TransitionLatestQueueEntryButton', () => {
     });
   });
 
-  it('should render a button', () => {
+  it('should render a button when an active visit exists', () => {
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
     expect(screen.getByRole('button', { name: /transition/i })).toBeInTheDocument();
@@ -51,11 +51,10 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
-  it('should disable the button when no active visit exists', () => {
+  it('should not render the button when no active visit exists', () => {
     (useVisit as jest.Mock).mockReturnValue({
       activeVisit: null,
       isLoading: false,
@@ -63,6 +62,6 @@ describe('TransitionLatestQueueEntryButton', () => {
 
     render(<TransitionLatestQueueEntryButton patientUuid={patientUuid} />);
 
-    expect(screen.getByRole('button', { name: /transition/i })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /transition/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Previously, the "Transition" button was available even when a patient did not have an active visit, leading to unintended actions. This update ensures that the button is hidden for patients without an active visit, preventing errors in patient transitions.
Additionally, a modal has been added to allow adding the patient to the queue before transitioning, ensuring a smooth and structured workflow.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots
Bug video
![imagingBug](https://github.com/user-attachments/assets/85e58c46-fba0-46a6-8b83-f15c023cdab8)

Fix video
![fix-imaging](https://github.com/user-attachments/assets/aa24c9c6-a977-4ef1-8c53-daea0a13acd7)


Procedure fix
![procedure-disable](https://github.com/user-attachments/assets/06eb38f7-db76-4298-b71f-7cdcd2817b58)


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://thepalladiumgroup.atlassian.net/browse/KHP3-7654

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
