### PR TITLE
KHP3-8147: Enhace the procedure order form to include the operation category e.g minor and major and also under the priority add emergency and elective.

### DIFF
--- a/packages/esm-procedure-orders-app/src/form/procedures-orders/add-procedures-order/procedures-order-form.component.tsx
+++ b/packages/esm-procedure-orders-app/src/form/procedures-orders/add-procedures-order/procedures-order-form.component.tsx
@@ -25,7 +25,7 @@ import {
   NumberInput,
 } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import { priorityOptions } from './procedures-order';
+import { categoryItems, priorityOptions } from './procedures-order';
 import { useProceduresTypes } from './useProceduresTypes';
 import { Controller, type FieldErrors, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -88,6 +88,7 @@ export function ProceduresOrderForm({
         invalid_type_error: translateFrom(moduleName, 'addLabOrderLabReferenceRequired', 'Test type is required'),
       },
     ),
+    category: z.string().optional(),
     orderReason: orderReasonRequired
       ? z
           .string({
@@ -182,7 +183,6 @@ export function ProceduresOrderForm({
       <Form className={styles.orderForm} onSubmit={handleSubmit(handleFormSubmission, onError)} id="procedureOrderForm">
         <div className={styles.form}>
           <ExtensionSlot name="top-of-procedure-order-form-slot" state={{ order: initialOrder }} />
-
           <Grid className={styles.gridRow}>
             <Column lg={16} md={8} sm={4}>
               <InputWrapper>
@@ -204,6 +204,28 @@ export function ProceduresOrderForm({
                       onChange={({ selectedItem }) => onChange(selectedItem)}
                       invalid={errors.testType?.message}
                       invalidText={errors.testType?.message}
+                    />
+                  )}
+                />
+              </InputWrapper>
+            </Column>
+            <Column lg={16} md={8} sm={4}>
+              <InputWrapper>
+                <Controller
+                  name="category"
+                  control={control}
+                  render={({ field: { onChange, onBlur, value }, fieldState: { error } }) => (
+                    <ComboBox
+                      size="lg"
+                      id="categoryInput"
+                      titleText={t('category', 'Category')}
+                      selectedItem={categoryItems.find((option) => option.value === value) || null}
+                      items={categoryItems}
+                      placeholder={t('categoryPlaceholder', 'Select one')}
+                      onBlur={onBlur}
+                      onChange={({ selectedItem }) => onChange(selectedItem?.value || '')}
+                      invalid={error?.message}
+                      invalidText={error?.message}
                     />
                   )}
                 />

--- a/packages/esm-procedure-orders-app/src/form/procedures-orders/add-procedures-order/procedures-order.ts
+++ b/packages/esm-procedure-orders-app/src/form/procedures-orders/add-procedures-order/procedures-order.ts
@@ -2,9 +2,14 @@ import { type ProcedureOrderBasketItem } from '../../../types';
 import { type ProceduresType } from './useProceduresTypes';
 
 export const priorityOptions = [
-  { value: 'ROUTINE', label: 'Routine' },
-  { value: 'STAT', label: 'Stat' },
-  { value: 'ON_SCHEDULED_DATE', label: 'Scheduled' },
+  { value: 'STAT', label: 'Emergency' },
+  { value: 'ROUTINE', label: 'Elective' },
+  // { value: 'ON_SCHEDULED_DATE', label: 'Scheduled' },
+];
+
+export const categoryItems = [
+  { value: '3c3946b1-d71d-41b3-a2e4-2d755006200a', label: 'Minor' },
+  { value: '3798940f-87b8-464e-b36a-17da246f034e', label: 'Major' },
 ];
 
 export function createEmptyLabOrder(testType: ProceduresType, orderer: string): ProcedureOrderBasketItem {

--- a/packages/esm-procedure-orders-app/src/form/procedures-orders/api.ts
+++ b/packages/esm-procedure-orders-app/src/form/procedures-orders/api.ts
@@ -101,9 +101,11 @@ export function prepProceduresOrderPostData(
       orderReason: order.orderReason,
       orderReasonNonCoded: order.orderReasonNonCoded,
       bodySite: order.bodySite,
+      category: order.category,
     };
     if (order.urgency === 'ON_SCHEDULED_DATE') {
-      payload['scheduledDate'] = order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
+      payload['scheduledDate'] =
+        order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
     }
     return payload;
   } else if (order.action === 'REVISE') {
@@ -125,9 +127,11 @@ export function prepProceduresOrderPostData(
       orderReason: order.orderReason,
       orderReasonNonCoded: order.orderReasonNonCoded,
       previousOrder: order.previousOrder,
+      category: order.category,
     };
     if (order.urgency === 'ON_SCHEDULED_DATE') {
-      payload['scheduledDate'] = order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
+      payload['scheduledDate'] =
+        order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
     }
     return payload;
   } else if (order.action === 'DISCONTINUE') {
@@ -150,7 +154,8 @@ export function prepProceduresOrderPostData(
       previousOrder: order.previousOrder,
     };
     if (order.urgency === 'ON_SCHEDULED_DATE') {
-      payload['scheduledDate'] = order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
+      payload['scheduledDate'] =
+        order.scheduleDate instanceof Date ? order.scheduleDate.toISOString() : order.scheduleDate;
     }
     return payload;
   } else {

--- a/packages/esm-procedure-orders-app/src/types/index.ts
+++ b/packages/esm-procedure-orders-app/src/types/index.ts
@@ -419,6 +419,7 @@ export interface ProcedureOrderBasketItem extends OrderBasketItem {
     label: string;
     conceptUuid: string;
   };
+  category?: string;
   labReferenceNumber?: string;
   urgency?: OrderUrgency;
   instructions?: string;


### PR DESCRIPTION

## Requirements

- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

https://github.com/user-attachments/assets/64bbf950-fd18-4eb9-9909-a91ec9a7c0ba


*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue
https://thepalladiumgroup.atlassian.net/browse/KHP3-8147
*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
